### PR TITLE
Поддержка виджета в Центре управления

### DIFF
--- a/Yandex Music.xcodeproj/project.pbxproj
+++ b/Yandex Music.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		666157FC27CC1A4B00456E3E /* init.js in Resources */ = {isa = PBXBuildFile; fileRef = 666157FB27CC1A4B00456E3E /* init.js */; };
 		A50AE66527B5B4F900F01BFA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50AE66427B5B4F900F01BFA /* AppDelegate.swift */; };
 		A50AE66727B5B4F900F01BFA /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50AE66627B5B4F900F01BFA /* MainViewController.swift */; };
 		A50AE66927B5B4FA00F01BFA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A50AE66827B5B4FA00F01BFA /* Assets.xcassets */; };
@@ -25,6 +26,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		666157FB27CC1A4B00456E3E /* init.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = init.js; sourceTree = "<group>"; };
 		A50AE66127B5B4F900F01BFA /* Я.Музыка.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Я.Музыка.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A50AE66427B5B4F900F01BFA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A50AE66627B5B4F900F01BFA /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
@@ -74,6 +76,7 @@
 		A50AE66327B5B4F900F01BFA /* Yandex Music */ = {
 			isa = PBXGroup;
 			children = (
+				666157FB27CC1A4B00456E3E /* init.js */,
 				A50AE66427B5B4F900F01BFA /* AppDelegate.swift */,
 				A50AE66627B5B4F900F01BFA /* MainViewController.swift */,
 				A53E0B7727B646DE006B2253 /* SettingsViewController.swift */,
@@ -175,6 +178,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				666157FC27CC1A4B00456E3E /* init.js in Resources */,
 				A50AE66927B5B4FA00F01BFA /* Assets.xcassets in Resources */,
 				A570E48B27B6BF5500BF6E73 /* Full.storyboard in Resources */,
 			);

--- a/Yandex Music/MainViewController.swift
+++ b/Yandex Music/MainViewController.swift
@@ -158,7 +158,8 @@ extension MainViewController: WKNavigationDelegate {
                 });
 
                 externalAPI.on(externalAPI.EVENT_PROGRESS, () => {
-                    const progress = externalAPI.getProgress({
+                    const progress = externalAPI.getProgress();
+                    navigator.mediaSession.setPositionState({
                         duration: progress.duration,
                         playbackRate: externalAPI.getSpeed(),
                         position: progress.position

--- a/Yandex Music/MainViewController.swift
+++ b/Yandex Music/MainViewController.swift
@@ -124,52 +124,11 @@ extension MainViewController: WKNavigationDelegate {
     }
     
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        webView.evaluateJavaScript("""
-            if ('mediaSession' in navigator && externalAPI) {
-                navigator.mediaSession.setActionHandler('play', () => {
-                    externalAPI.togglePause(false);
-                });
-                navigator.mediaSession.setActionHandler('pause', () => {
-                    externalAPI.togglePause(true);
-                });
-                navigator.mediaSession.setActionHandler('seekto', ({ seekTime }) => {
-                    externalAPI.setPosition(seekTime);
-                });
-                const updateControls = () => {
-                    const controls = externalAPI.getControls();
-                    navigator.mediaSession.setActionHandler("previoustrack", controls.prev ? externalAPI.prev : null);
-                    navigator.mediaSession.setActionHandler("nexttrack", controls.next ? externalAPI.next : null);
-                }
-                externalAPI.on(externalAPI.EVENT_CONTROLS, updateControls);
-                updateControls();
-
-                externalAPI.on(externalAPI.EVENT_TRACK, () => {
-                    const track = externalAPI.getCurrentTrack();
-                    navigator.mediaSession.metadata = new MediaMetadata({
-                        title: track.title || "",
-                        artist: track.artists.map((a) => a.title).join(", "),
-                        album: track.album ? track.album.title : "",
-                        artwork: track.cover ? [{
-                            src: "https://"+track.cover.replace("%%", "200x200"),
-                            sizes: "200x200",
-                            type: "image/jpeg"
-                        }] : []
-                    });
-                });
-
-                externalAPI.on(externalAPI.EVENT_PROGRESS, () => {
-                    const progress = externalAPI.getProgress();
-                    navigator.mediaSession.setPositionState({
-                        duration: progress.duration,
-                        playbackRate: externalAPI.getSpeed(),
-                        position: progress.position
-                    });
-                });
-                externalAPI.on(externalAPI.EVENT_STATE, () => {
-                    navigator.mediaSession.playbackState = externalAPI.isPlaying() ? "playing" : "paused";
-                });
-            }
-        """)
+        let path = Bundle.main.path(forResource: "init", ofType: "js")!
+        let initJS = try? String(contentsOfFile: path, encoding: String.Encoding.utf8)
+        if (initJS != nil) {
+            webView.evaluateJavaScript(initJS!)
+        }
     }
     
 }

--- a/Yandex Music/MainViewController.swift
+++ b/Yandex Music/MainViewController.swift
@@ -123,6 +123,54 @@ extension MainViewController: WKNavigationDelegate {
         errorView.isHidden = false
     }
     
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        webView.evaluateJavaScript("""
+            if ('mediaSession' in navigator && externalAPI) {
+                navigator.mediaSession.setActionHandler('play', () => {
+                    externalAPI.togglePause(false);
+                });
+                navigator.mediaSession.setActionHandler('pause', () => {
+                    externalAPI.togglePause(true);
+                });
+                navigator.mediaSession.setActionHandler('seekto', ({ seekTime }) => {
+                    externalAPI.setPosition(seekTime);
+                });
+                const updateControls = () => {
+                    const controls = externalAPI.getControls();
+                    navigator.mediaSession.setActionHandler("previoustrack", controls.prev ? externalAPI.prev : null);
+                    navigator.mediaSession.setActionHandler("nexttrack", controls.next ? externalAPI.next : null);
+                }
+                externalAPI.on(externalAPI.EVENT_CONTROLS, updateControls);
+                updateControls();
+
+                externalAPI.on(externalAPI.EVENT_TRACK, () => {
+                    const track = externalAPI.getCurrentTrack();
+                    navigator.mediaSession.metadata = new MediaMetadata({
+                        title: track.title || "",
+                        artist: track.artists.map((a) => a.title).join(", "),
+                        album: track.album ? track.album.title : "",
+                        artwork: track.cover ? [{
+                            src: "https://"+track.cover.replace("%%", "200x200"),
+                            sizes: "200x200",
+                            type: "image/jpeg"
+                        }] : []
+                    });
+                });
+
+                externalAPI.on(externalAPI.EVENT_PROGRESS, () => {
+                    const progress = externalAPI.getProgress({
+                        duration: progress.duration,
+                        playbackRate: externalAPI.getSpeed(),
+                        position: progress.position
+                    });
+                });
+                externalAPI.on(externalAPI.EVENT_STATE, () => {
+                    navigator.mediaSession.playbackState = externalAPI.isPlaying() ? "playing" : "paused";
+                });
+            }
+        """)
+    }
+    
 }
 
 // MARK: - WebKit UI Delegate

--- a/Yandex Music/init.js
+++ b/Yandex Music/init.js
@@ -1,0 +1,57 @@
+if ("mediaSession" in navigator && externalAPI) {
+    navigator.mediaSession.setActionHandler("play", () => {
+        externalAPI.togglePause(false);
+    });
+    navigator.mediaSession.setActionHandler("pause", () => {
+        externalAPI.togglePause(true);
+    });
+    navigator.mediaSession.setActionHandler("seekto", ({ seekTime }) => {
+        externalAPI.setPosition(seekTime);
+    });
+    const updateControls = () => {
+        const controls = externalAPI.getControls();
+        navigator.mediaSession.setActionHandler(
+            "previoustrack",
+            controls.prev ? externalAPI.prev : null,
+        );
+        navigator.mediaSession.setActionHandler(
+            "nexttrack",
+            controls.next ? externalAPI.next : null,
+        );
+    };
+    externalAPI.on(externalAPI.EVENT_CONTROLS, updateControls);
+    updateControls();
+
+    externalAPI.on(externalAPI.EVENT_TRACK, () => {
+        const track = externalAPI.getCurrentTrack();
+        navigator.mediaSession.metadata = new MediaMetadata({
+            title: track.title || "",
+            artist: track.artists.map((a) => a.title).join(", "),
+            album: track.album ? track.album.title : "",
+            artwork: track.cover
+                ? [
+                      {
+                          src:
+                              "https://" + track.cover.replace("%%", "200x200"),
+                          sizes: "200x200",
+                          type: "image/jpeg",
+                      },
+                  ]
+                : [],
+        });
+    });
+
+    externalAPI.on(externalAPI.EVENT_PROGRESS, () => {
+        const progress = externalAPI.getProgress();
+        navigator.mediaSession.setPositionState({
+            duration: progress.duration,
+            playbackRate: externalAPI.getSpeed(),
+            position: progress.position,
+        });
+    });
+    externalAPI.on(externalAPI.EVENT_STATE, () => {
+        navigator.mediaSession.playbackState = externalAPI.isPlaying()
+            ? "playing"
+            : "paused";
+    });
+}


### PR DESCRIPTION
Приветствую!
Благодарю за чудесное приложение, использую вместо браузерного дополнения к хрому, нравится.

**Проблема**
С некоторых пор в macOS появился Control Centre, а в нём — виджет «Now Playing».
И с музыкой из приложения он выглядит так:
![Screenshot 2022-02-24 at 02 51 32](https://user-images.githubusercontent.com/281098/155455331-d73d5dd6-f6e4-4658-9266-f77945d0e297.png)
При этом работает только кнопка паузы и прокрутка (не каждый раз).


**Решение**
Не знаю точный алгоритм, по которому Now Playing определяет что собственно сейчас играет, но он явно дружит с [MediaSession браузера](https://developer.mozilla.org/en-US/docs/Web/API/MediaSession). По крайней мере на Monterey 12.2.1 + Safari 15.3.
А значит, достаточно в скриптах изнутри страницы Яндекс.Музыки настроить этот самый MediaSession. Странно, что Яндекс ещё не сделал этого сам.

Я дописал небольшой JS при загрузке страницы, который ловит события от яндексового externalAPI и заполняет соответствующими значениями MediaSession. И выдаёт наружу ручки, которые дёргаются из виджета — вперёд, назад, прокрутка.

По итогам выглядит так:
![Screenshot 2022-02-24 at 06 01 16](https://user-images.githubusercontent.com/281098/155455344-54a64020-a36f-4377-a3c0-470734c916d5.png)


**Известные баги**
При переключении трека из виджета кнопка «Далее» в виджете иногда перестаёт быть доступной, хотя updateControls отрабатывает. Кнопки в виджете обновляются сами собой если подождать, или если чуть промотать трек.
При выставлении трека на паузу из виджета прогресс в виджете выставляется в 0:00/0:00, не каждый раз, но часто. В MediaSession при этом нулей не отправляется.

Буду рад замечаниям и дополнениям, swift — не мой родной язык.
Что скажете?