### PR TITLE
Скрытие приложения по нажатию на кнопку "Закрыть"

### DIFF
--- a/Yandex Music/MainViewController.swift
+++ b/Yandex Music/MainViewController.swift
@@ -184,8 +184,8 @@ extension MainViewController: EventHelper.Target {
 extension MainViewController: NSWindowDelegate {
     
     func windowShouldClose(_ sender: NSWindow) -> Bool {
-        NSApplication.shared.terminate(self)
-        return true
+        NSApp.hide(nil)
+        return false
     }
     
 }


### PR DESCRIPTION
Отличное приложение, спасибо!

Единственное, что было неожиданно для меня - полное закрытие по нажатию на кнопку "Закрыть". Большинство приложений на Маке скрываются, включая Music.app

В этом PR сделал скрытие вместо закрытия